### PR TITLE
Set up email config to use default correctly

### DIFF
--- a/classes/Kohana/Email.php
+++ b/classes/Kohana/Email.php
@@ -56,14 +56,14 @@ class Kohana_Email {
 					->as_array();
 			}
 
-			if ( ! isset($config[$name]))
+			if ( ! isset($config[$name]) && ! isset($config[Email::$default]))
 			{
 				throw new Kohana_Exception(':name configuration is not defined',
 					array(':name' => $name));
 			}
 
 			// Store the email instance
-			Email::$instances[$name] = new Email($name, $config[$name]);
+			Email::$instances[$name] = new Email($name, (isset($config[$name]) ? $config[$name] : $config[Email::$default]));
 		}
 
 		return Email::$instances[$name];


### PR DESCRIPTION
If an instance name does not match a config name use the default config instead if it exists, otherwise throw an exception.
